### PR TITLE
Détruire la popup lorsque la souris quitte le signalement

### DIFF
--- a/src/js/signalement.js
+++ b/src/js/signalement.js
@@ -833,7 +833,8 @@ Signalement.signalement = (function () {
             selectFeatureCtrl = new OpenLayers.Control.SelectFeature(wfsLayer, {
                 hover: enableSelectOver,
                 // Fait reference a la fonction popUp
-                onSelect: popUP
+                onSelect: popUP,
+                onUnselect: function(){popup.destroy();}
                 //selectStyle :feature_style
 
             });


### PR DESCRIPTION
Ajout de d'un trigger pour fermer automatiquement la popup info lorsque la souris quitte le signalement.